### PR TITLE
Add animated water preloader for landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import LandingPage from './components/LandingPage'
 import AboutPage from './components/AboutPage'
 import Navigation from './components/Navigation'
+import Preloader from './components/Preloader'
 
 const PageTransition = ({ children }) => (
   <motion.div
@@ -18,30 +20,88 @@ const PageTransition = ({ children }) => (
 
 const App = () => {
   const location = useLocation()
+  const [isLoading, setIsLoading] = useState(true)
+  const [isPreloaderVisible, setIsPreloaderVisible] = useState(true)
+
+  useEffect(() => {
+    let fadeTimeout
+    let safetyTimeout
+
+    const finishLoading = () => {
+      if (fadeTimeout) {
+        return
+      }
+
+      if (safetyTimeout) {
+        window.clearTimeout(safetyTimeout)
+      }
+
+      fadeTimeout = window.setTimeout(() => {
+        setIsLoading(false)
+      }, 400)
+    }
+
+    safetyTimeout = window.setTimeout(finishLoading, 5000)
+
+    if (document.readyState === 'complete') {
+      finishLoading()
+    } else {
+      window.addEventListener('load', finishLoading)
+    }
+
+    return () => {
+      window.removeEventListener('load', finishLoading)
+      if (fadeTimeout) {
+        window.clearTimeout(fadeTimeout)
+      }
+      if (safetyTimeout) {
+        window.clearTimeout(safetyTimeout)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    let timeoutId
+
+    if (!isLoading) {
+      timeoutId = window.setTimeout(() => {
+        setIsPreloaderVisible(false)
+      }, 800)
+    }
+
+    return () => {
+      if (timeoutId) {
+        window.clearTimeout(timeoutId)
+      }
+    }
+  }, [isLoading])
 
   return (
     <>
-      <Navigation />
-      <AnimatePresence mode="wait">
-        <Routes location={location} key={location.pathname}>
-          <Route
-            path="/"
-            element={
-              <PageTransition>
-                <LandingPage />
-              </PageTransition>
-            }
-          />
-          <Route
-            path="/about"
-            element={
-              <PageTransition>
-                <AboutPage />
-              </PageTransition>
-            }
-          />
-        </Routes>
-      </AnimatePresence>
+      {isPreloaderVisible && <Preloader isClosing={!isLoading} />}
+      <div className={`app-shell${isLoading ? ' app-shell--hidden' : ''}`}>
+        <Navigation />
+        <AnimatePresence mode="wait">
+          <Routes location={location} key={location.pathname}>
+            <Route
+              path="/"
+              element={
+                <PageTransition>
+                  <LandingPage />
+                </PageTransition>
+              }
+            />
+            <Route
+              path="/about"
+              element={
+                <PageTransition>
+                  <AboutPage />
+                </PageTransition>
+              }
+            />
+          </Routes>
+        </AnimatePresence>
+      </div>
     </>
   )
 }

--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -1,17 +1,21 @@
 import { useEffect, useId } from 'react'
 
 const Preloader = ({ isClosing = false }) => {
-  const uniqueId = useId()
-  const patternId = `${uniqueId}-water-pattern`
-  const textId = `${uniqueId}-wordmark`
-  const maskId = `${uniqueId}-mask`
+  // делаем id безопасным для url(#id)
+  const raw = useId()
+  const uid = raw.replace(/[^a-zA-Z0-9_-]/g, '')   // убираем двоеточия и т.п.
+
+  const textId = `${uid}-wordmark`
+  const maskId = `${uid}-mask`
+  const waveTileId = `${uid}-wave-tile`
+
+  // размеры в одном месте (чтобы не забыть поменять в нескольких тегах)
+  const VB_WIDTH = 900
+  const VB_HEIGHT = 160
 
   useEffect(() => {
     document.body.classList.add('preloader-active')
-
-    return () => {
-      document.body.classList.remove('preloader-active')
-    }
+    return () => document.body.classList.remove('preloader-active')
   }, [])
 
   return (
@@ -19,62 +23,69 @@ const Preloader = ({ isClosing = false }) => {
       <div className="preloader__inner" role="img" aria-label="PRAGMATICS loading">
         <svg
           className="preloader__svg"
-          viewBox="0 0 620 140"
+          viewBox={`0 0 ${VB_WIDTH} ${VB_HEIGHT}`}
           xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
         >
           <defs>
-            <pattern
-              id={patternId}
-              width="0.25"
-              height="1.1"
-              patternContentUnits="objectBoundingBox"
-            >
-              <path
-                fill="#ffffff"
-                d="M0.25,1H0c0,0,0-0.659,0-0.916c0.083-0.303,0.158,0.334,0.25,0C0.25,0.327,0.25,1,0.25,1z"
-              />
-              <animateTransform
-                attributeName="patternTransform"
-                type="translate"
-                from="0 0"
-                to="1 0"
-                dur="0.8s"
-                repeatCount="indefinite"
-              />
-            </pattern>
-
+            {/* Текст — только для маски */}
             <text
               id={textId}
               x="50%"
-              y="104"
-              fontFamily="'Cabin Condensed', 'Arial Narrow', sans-serif"
-              fontSize="100"
-              letterSpacing="8"
+              y="112"                        /* подогнано под VB_HEIGHT=160 */
+              fontFamily="Arial, Helvetica, sans-serif"
+              fontSize="120"
+              fontWeight="700"
+              letterSpacing="6"
               textAnchor="middle"
             >
               PRAGMATICS
             </text>
 
+            {/* Маска: белое видно */}
             <mask id={maskId}>
-              <use xlinkHref={`#${textId}`} fill="#ffffff" />
+              <rect width="100%" height="100%" fill="#000" />
+              <use href={`#${textId}`} fill="#fff" />
             </mask>
+
+            {/* Тайловая волна (userSpaceOnUse!) */}
+            <pattern id={waveTileId} width="160" height="60" patternUnits="userSpaceOnUse">
+              <path
+                d="
+                  M0,30
+                  c20,-10 40,-10 60,0
+                  c20,10  40,10  60,0
+                  c20,-10 40,-10 60,0
+                  V60 H0 Z
+                "
+                fill="#fff"
+              />
+            </pattern>
           </defs>
 
-          <use
-            className="preloader__svg-outline"
-            xlinkHref={`#${textId}`}
-          />
+          {/* Контур текста для читабельности */}
+          <use className="preloader__svg-outline" href={`#${textId}`} />
 
+          {/* Вода видна только внутри текста */}
           <g className="preloader__water-container" mask={`url(#${maskId})`}>
-            <rect
-              className="preloader__water"
-              x="-620"
-              y="-20"
-              width="1240"
-              height="180"
-              fill={`url(#${patternId})`}
-            />
+            <g className="preloader__wave preloader__wave--one">
+              <rect
+                x={-VB_WIDTH}
+                y={VB_HEIGHT * 0.56}        // позиция уровня
+                width={VB_WIDTH * 2.2}
+                height="80"
+                fill={`url(#${waveTileId})`}
+              />
+            </g>
+
+            <g className="preloader__wave preloader__wave--two">
+              <rect
+                x={-VB_WIDTH}
+                y={VB_HEIGHT * 0.61}
+                width={VB_WIDTH * 2.2}
+                height="80"
+                fill={`url(#${waveTileId})`}
+              />
+            </g>
           </g>
         </svg>
       </div>

--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+const Preloader = ({ isClosing = false }) => {
+  useEffect(() => {
+    document.body.classList.add('preloader-active')
+
+    return () => {
+      document.body.classList.remove('preloader-active')
+    }
+  }, [])
+
+  return (
+    <div className={`preloader${isClosing ? ' preloader--closing' : ''}`}>
+      <div className="preloader__inner">
+        <span className="preloader__text preloader__text--base">PRAGMATICS</span>
+        <span
+          className="preloader__text preloader__text--fill"
+          aria-hidden="true"
+        >
+          PRAGMATICS
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default Preloader

--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -42,8 +42,16 @@ const Preloader = ({ isClosing = false }) => {
             </text>
 
             {/* Маска: белое видно */}
-            <mask id={maskId}>
-              <rect width="100%" height="100%" fill="#000" />
+            <mask
+              id={maskId}
+              maskUnits="userSpaceOnUse"
+              maskContentUnits="userSpaceOnUse"
+              x="0"
+              y="0"
+              width={VB_WIDTH}
+              height={VB_HEIGHT}
+            >
+              <rect width={VB_WIDTH} height={VB_HEIGHT} fill="#000" />
               <use href={`#${textId}`} fill="#fff" />
             </mask>
 

--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -1,6 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useId } from 'react'
 
 const Preloader = ({ isClosing = false }) => {
+  const uniqueId = useId()
+  const patternId = `${uniqueId}-water-pattern`
+  const textId = `${uniqueId}-wordmark`
+  const maskId = `${uniqueId}-mask`
+
   useEffect(() => {
     document.body.classList.add('preloader-active')
 
@@ -11,14 +16,67 @@ const Preloader = ({ isClosing = false }) => {
 
   return (
     <div className={`preloader${isClosing ? ' preloader--closing' : ''}`}>
-      <div className="preloader__inner">
-        <span className="preloader__text preloader__text--base">PRAGMATICS</span>
-        <span
-          className="preloader__text preloader__text--fill"
-          aria-hidden="true"
+      <div className="preloader__inner" role="img" aria-label="PRAGMATICS loading">
+        <svg
+          className="preloader__svg"
+          viewBox="0 0 620 140"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
         >
-          PRAGMATICS
-        </span>
+          <defs>
+            <pattern
+              id={patternId}
+              width="0.25"
+              height="1.1"
+              patternContentUnits="objectBoundingBox"
+            >
+              <path
+                fill="#ffffff"
+                d="M0.25,1H0c0,0,0-0.659,0-0.916c0.083-0.303,0.158,0.334,0.25,0C0.25,0.327,0.25,1,0.25,1z"
+              />
+              <animateTransform
+                attributeName="patternTransform"
+                type="translate"
+                from="0 0"
+                to="1 0"
+                dur="0.8s"
+                repeatCount="indefinite"
+              />
+            </pattern>
+
+            <text
+              id={textId}
+              x="50%"
+              y="104"
+              fontFamily="'Cabin Condensed', 'Arial Narrow', sans-serif"
+              fontSize="100"
+              letterSpacing="8"
+              textAnchor="middle"
+            >
+              PRAGMATICS
+            </text>
+
+            <mask id={maskId}>
+              <use xlinkHref={`#${textId}`} fill="#ffffff" />
+            </mask>
+          </defs>
+
+          <use
+            className="preloader__svg-outline"
+            xlinkHref={`#${textId}`}
+          />
+
+          <g className="preloader__water-container" mask={`url(#${maskId})`}>
+            <rect
+              className="preloader__water"
+              x="-620"
+              y="-20"
+              width="1240"
+              height="180"
+              fill={`url(#${patternId})`}
+            />
+          </g>
+        </svg>
       </div>
     </div>
   )

--- a/style.css
+++ b/style.css
@@ -1,9 +1,17 @@
-@import url('https://fonts.googleapis.com/css2?family=Cabin+Condensed:wght@700&display=swap');
+/* @import url('https://fonts.googleapis.com/css2?family=Cabin+Condensed:wght@700&display=swap'); */
+
+/* === Настраиваемые длительности/скорости === */
+:root{
+  --preloader-rise: 5s;
+  --preloader-fade: 0.8s;
+  --wave-speed-1: 6s;
+  --wave-speed-2: 9s;
+}
 
 .app-shell {
   position: relative;
   opacity: 1;
-  transition: opacity 0.8s ease;
+  transition: opacity var(--preloader-fade) ease;
   will-change: opacity;
 }
 
@@ -25,7 +33,7 @@ body.preloader-active {
   background: #000;
   overflow: hidden;
   z-index: 4000;
-  transition: opacity 0.8s ease, visibility 0.8s ease;
+  transition: opacity var(--preloader-fade) ease, visibility var(--preloader-fade) ease;
 }
 
 .preloader--closing {
@@ -49,48 +57,63 @@ body.preloader-active {
 }
 
 .preloader__svg-outline {
-  fill: transparent;
-  stroke: rgba(255, 255, 255, 0.75);
+  fill: none;
+  stroke: rgba(255,255,255,.75);
   stroke-width: 4;
 }
 
-.preloader__water-container {
+
+.preloader__water-container,
+.preloader__wave {
+  transform-box: fill-box;     /* ключевая строка */
+}
+
+
+/* ====== ВОДА ВНУТРИ ТЕКСТА ====== */
+/* Подъём уровня */
+.preloader__water-container{
   transform-origin: center bottom;
   transform: translateY(60%) scaleY(0);
-  animation: preloaderWaterRise 3.8s cubic-bezier(0.32, 0.02, 0.25, 1) forwards 0.3s;
+  animation: preloaderWaterRise var(--preloader-rise) cubic-bezier(.32,.02,.25,1) forwards .3s;
 }
+
+/* Бегущие волны — видны только внутри маски текста (см. JSX) */
+.preloader__wave { will-change: transform; }
+
+.preloader__wave{ will-change: transform; }
+@keyframes waveX {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-160px); } /* ширина тайла */
+}
+
+.preloader__wave--one{ animation: waveX var(--wave-speed-1) linear infinite; opacity:.9; }
+.preloader__wave--two{ animation: waveX var(--wave-speed-2) linear infinite; opacity:.7; transform: translateX(-40px); }
 
 .preloader__water {
-  opacity: 0.95;
+  opacity: 0.95; /* если нужен дополнительный белый слой */
 }
 
-@keyframes preloaderWaterRise {
-  0% {
-    transform: translateY(60%) scaleY(0);
-  }
-
-  60% {
-    transform: translateY(6%) scaleY(0.92);
-  }
-
-  100% {
-    transform: translateY(0) scaleY(1);
-  }
+@keyframes preloaderWaterRise{
+  0%{ transform: translateY(60%) scaleY(0); }
+  60%{ transform: translateY(6%)  scaleY(.92); }
+  100%{ transform: translateY(0)   scaleY(1); }
 }
 
-@media (prefers-reduced-motion: reduce) {
+/* @media (prefers-reduced-motion: reduce) {
   .preloader,
   .app-shell,
-  .preloader__water-container {
+  .preloader__water-container,
+  .preloader__wave {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-
   .preloader__water-container {
     transform: translateY(0) scaleY(1);
   }
-}
+} */
+
+/* ====== остальная верстка ====== */
 
 .landing-body {
   margin: 0;
@@ -120,6 +143,7 @@ body.preloader-active {
   -moz-object-fit: cover;
   z-index: 0;
 }
+
 .logo-container {
   position: fixed;
   top: 50%;
@@ -146,6 +170,7 @@ body.preloader-active {
   pointer-events: none;
   object-fit: contain;
 }
+
 #logo3d {
   width: 1920px;
   height: 1080px;
@@ -159,6 +184,7 @@ body.preloader-active {
   background: transparent !important;
   pointer-events: auto;
 }
+
 .logo-overlay {
   position: absolute;
   width: 100%;
@@ -191,6 +217,7 @@ body.preloader-active {
   opacity: 0.8;
   border-radius: 8px;
 }
+
 .logo-img {
   position: absolute;
   width: 80vw;
@@ -206,6 +233,7 @@ body.preloader-active {
   -webkit-object-fit: cover;
   z-index: 2;
 }
+
 .main-bg {
   position: fixed;
   top: 0;
@@ -215,6 +243,7 @@ body.preloader-active {
   z-index: 200;
   pointer-events: none;
 }
+
 .masked-video {
   width: 100vw;
   height: 100vh;
@@ -234,6 +263,7 @@ body.preloader-active {
   background: #000;
   display: block;
 }
+
 .logo-overlay-container {
   position: relative;
   width: 600px;
@@ -242,6 +272,7 @@ body.preloader-active {
   justify-content: center;
   align-items: center;
 }
+
 .logo-base {
   position: absolute;
   top: 0;
@@ -250,6 +281,7 @@ body.preloader-active {
   height: auto;
   display: block;
 }
+
 .side-text {
   position: fixed;
   top: 95%;
@@ -265,14 +297,10 @@ body.preloader-active {
     text-shadow 0.3s;
   text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
 }
-.side-text.left {
-  left: 2vw;
-  text-align: left;
-}
-.side-text.right {
-  right: 2vw;
-  text-align: right;
-}
+
+.side-text.left { left: 2vw; text-align: left; }
+.side-text.right { right: 2vw; text-align: right; }
+
 .side-text:hover {
   color: hsl(0, 0%, 100%);
   text-shadow:
@@ -295,14 +323,10 @@ body.preloader-active {
     text-shadow 0.3s;
   text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
 }
-.side-text2.left {
-  left: 2vw;
-  text-align: left;
-}
-.side-text2.right {
-  right: 2vw;
-  text-align: right;
-}
+
+.side-text2.left { left: 2vw; text-align: left; }
+.side-text2.right { right: 2vw; text-align: right; }
+
 .side-text2:hover {
   color: hsl(0, 0%, 100%);
   text-shadow:
@@ -320,6 +344,7 @@ body.preloader-active {
   mix-blend-mode: normal;
   z-index: 1;
 }
+
 .gradient-bg {
   position: absolute;
   top: 0;
@@ -330,6 +355,7 @@ body.preloader-active {
   mix-blend-mode: hard-light;
   opacity: 1;
 }
+
 .gradient-mask {
   position: absolute;
   top: 50%;
@@ -343,6 +369,7 @@ body.preloader-active {
   mix-blend-mode: hard-light;
   pointer-events: none;
 }
+
 .mask-anim-wrapper {
   position: absolute;
   top: 50%;
@@ -359,8 +386,7 @@ body.preloader-active {
   mask-repeat: no-repeat;
   -webkit-mask-position: center;
   mask-position: center;
-  /* …остальные стили… */
-  --mask-max: 20.9vw; /* выберите нужный предел */
+  --mask-max: 20.9vw;
   -webkit-mask-size: min(35%, var(--mask-max)) auto;
   mask-size: min(35%, var(--mask-max)) auto;
   -moz-mask-image: url('SOURCE/PRAGMATICS BIG TXT/PRAGATICS.png');
@@ -369,6 +395,7 @@ body.preloader-active {
   -moz-mask-size: contain;
   overflow: hidden;
 }
+
 .gradient-bg-masked {
   position: absolute;
   top: 0;
@@ -390,6 +417,8 @@ body.preloader-active {
   transform: scale(0.3);
 }
 
+/* ====== медиазапросы ====== */
+
 @media screen and (min-width: 1920px) {
   .logo-container {
     width: 84vw;
@@ -397,23 +426,12 @@ body.preloader-active {
     max-width: 2160px;
     max-height: 1215px;
   }
-
-  .side-text,
-  .side-text2 {
-    display: none;
-  }
+  .side-text, .side-text2 { display: none; }
 }
 
 @media screen and (min-width: 1024px) and (max-width: 1919px) {
-  .logo-container {
-    width: 90vw;
-    height: 50.625vw;
-  }
-
-  .side-text,
-  .side-text2 {
-    font-size: clamp(14px, 0.9vw, 18px);
-  }
+  .logo-container { width: 90vw; height: 50.625vw; }
+  .side-text, .side-text2 { font-size: clamp(14px, 0.9vw, 18px); }
 }
 
 @media screen and (min-width: 768px) and (max-width: 1023px) {
@@ -423,21 +441,9 @@ body.preloader-active {
     max-width: 1440px;
     max-height: 810px;
   }
-
-  .side-text,
-  .side-text2 {
-    font-size: clamp(12px, 1.2vw, 16px);
-  }
-
-  .side-text.left,
-  .side-text2.left {
-    left: 3vw;
-  }
-
-  .side-text.right,
-  .side-text2.right {
-    right: 3vw;
-  }
+  .side-text, .side-text2 { font-size: clamp(12px, 1.2vw, 16px); }
+  .side-text.left, .side-text2.left { left: 3vw; }
+  .side-text.right, .side-text2.right { right: 3vw; }
 }
 
 @media screen and (max-width: 767px) {
@@ -447,95 +453,41 @@ body.preloader-active {
     max-width: 720px;
     max-height: 405px;
   }
-
-  .side-text,
-  .side-text2 {
+  .side-text, .side-text2 {
     font-size: clamp(10px, 2.5vw, 14px);
     letter-spacing: 0.1em;
   }
-
-  .side-text.left,
-  .side-text2.left {
-    left: 4vw;
-  }
-
-  .side-text.right,
-  .side-text2.right {
-    right: 4vw;
-  }
-
-  .side-text {
-    top: 92%;
-  }
-
-  .side-text2 {
-    top: 8%;
-  }
-
-  .side-text:hover,
-  .side-text2:hover {
+  .side-text.left, .side-text2.left { left: 4vw; }
+  .side-text.right, .side-text2.right { right: 4vw; }
+  .side-text { top: 92%; }
+  .side-text2 { top: 8%; }
+  .side-text:hover, .side-text2:hover {
     color: rgba(81, 98, 115, 0.6);
     text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
   }
 }
 
 @media screen and (max-width: 319px) {
-  .logo-container {
-    width: 114vw;
-    height: 64.125vw;
-  }
-
-  .side-text,
-  .side-text2 {
-    font-size: 10px;
-    letter-spacing: 0.05em;
-  }
-
-  .side-text.left,
-  .side-text2.left {
-    left: 5vw;
-  }
-
-  .side-text.right,
-  .side-text2.right {
-    right: 5vw;
-  }
+  .logo-container { width: 114vw; height: 64.125vw; }
+  .side-text, .side-text2 { font-size: 10px; letter-spacing: 0.05em; }
+  .side-text.left, .side-text2.left { left: 5vw; }
+  .side-text.right, .side-text2.right { right: 5vw; }
 }
 
 @media screen and (max-width: 767px) and (orientation: portrait) {
-  .logo-container {
-    width: 102vw;
-    height: 57.375vw;
-  }
+  .logo-container { width: 102vw; height: 57.375vw; }
 }
 
 @media screen and (max-width: 767px) and (orientation: landscape) {
-  .logo-container {
-    width: 84vw;
-    height: 47.25vw;
-  }
-
-  .side-text,
-  .side-text2 {
-    font-size: clamp(8px, 1.5vw, 12px);
-  }
+  .logo-container { width: 84vw; height: 47.25vw; }
+  .side-text, .side-text2 { font-size: clamp(8px, 1.5vw, 12px); }
 }
 
 @media screen and (min-aspect-ratio: 16/9) {
-  .logo-container {
-    width: 72vw;
-    height: 40.5vw;
-  }
+  .logo-container { width: 72vw; height: 40.5vw; }
 }
 
 @media screen and (min-aspect-ratio: 21/9) {
-  .logo-container {
-    width: 60vw;
-    height: 33.75vw;
-  }
-
-  .side-text,
-  .side-text2 {
-    font-size: clamp(12px, 0.7vw, 16px);
-  }
+  .logo-container { width: 60vw; height: 33.75vw; }
+  .side-text, .side-text2 { font-size: clamp(12px, 0.7vw, 16px); }
 }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,191 @@
+.app-shell {
+  position: relative;
+  opacity: 1;
+  transition: opacity 0.8s ease;
+  will-change: opacity;
+}
+
+.app-shell--hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.preloader-active {
+  overflow: hidden;
+}
+
+.preloader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #02060b;
+  overflow: hidden;
+  z-index: 4000;
+  transition: opacity 0.8s ease, visibility 0.8s ease;
+}
+
+.preloader::before {
+  content: '';
+  position: absolute;
+  inset: -35%;
+  background:
+    radial-gradient(
+      circle at 20% 25%,
+      rgba(255, 255, 255, 0.1) 0%,
+      rgba(255, 255, 255, 0) 55%
+    ),
+    radial-gradient(
+      circle at 80% 30%,
+      rgba(24, 72, 114, 0.45) 0%,
+      rgba(2, 6, 11, 0) 58%
+    ),
+    radial-gradient(
+      circle at 65% 75%,
+      rgba(13, 46, 82, 0.5) 0%,
+      rgba(2, 6, 11, 0) 62%
+    );
+  opacity: 0.65;
+  filter: blur(12px);
+  animation: preloaderShimmer 14s ease-in-out infinite;
+}
+
+.preloader--closing {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.preloader__inner {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+
+.preloader__text {
+  font-family: 'Arial Black', Arial, sans-serif;
+  font-size: clamp(32px, 6vw, 120px);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  text-align: center;
+  display: block;
+}
+
+.preloader__text--base {
+  color: transparent;
+  -webkit-text-stroke: 2px rgba(255, 255, 255, 0.35);
+  text-stroke: 2px rgba(255, 255, 255, 0.35);
+  opacity: 0.6;
+}
+
+.preloader__text--fill {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 0.12em;
+  color: #d8f0ff;
+  overflow: hidden;
+  transform: translateY(110%);
+  animation: preloaderFill 2.8s ease-in-out forwards 0.6s;
+  text-shadow:
+    0 0 24px rgba(93, 175, 255, 0.45),
+    0 0 48px rgba(62, 115, 173, 0.35);
+  z-index: 1;
+}
+
+.preloader__text--fill::before,
+.preloader__text--fill::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -18%;
+  width: 160%;
+  height: 160%;
+  border-radius: 45%;
+  transform: translate(-50%, 0) rotate(0deg);
+  filter: blur(3px);
+  z-index: -1;
+  mix-blend-mode: screen;
+}
+
+.preloader__text--fill::before {
+  background: rgba(64, 143, 219, 0.55);
+  animation: preloaderWave 6s linear infinite;
+}
+
+.preloader__text--fill::after {
+  background: rgba(150, 210, 255, 0.35);
+  animation: preloaderWave 8s linear infinite reverse;
+}
+
+@keyframes preloaderFill {
+  0% {
+    transform: translateY(110%);
+  }
+
+  45% {
+    transform: translateY(25%);
+  }
+
+  70% {
+    transform: translateY(8%);
+  }
+
+  100% {
+    transform: translateY(0%);
+  }
+}
+
+@keyframes preloaderWave {
+  0% {
+    transform: translate(-50%, 0) rotate(0deg);
+  }
+
+  50% {
+    transform: translate(-50%, -6%) rotate(180deg);
+  }
+
+  100% {
+    transform: translate(-50%, 0) rotate(360deg);
+  }
+}
+
+@keyframes preloaderShimmer {
+  0% {
+    transform: scale(1) translate(0, 0);
+  }
+
+  50% {
+    transform: scale(1.05) translate(2%, -1%);
+  }
+
+  100% {
+    transform: scale(1) translate(0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preloader,
+  .preloader::before,
+  .preloader__text--fill,
+  .preloader__text--fill::before,
+  .preloader__text--fill::after,
+  .app-shell {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .preloader__text--fill {
+    transform: translateY(0);
+  }
+}
+
 .landing-body {
   margin: 0;
   padding: 0;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Cabin+Condensed:wght@700&display=swap');
+
 .app-shell {
   position: relative;
   opacity: 1;
@@ -20,35 +22,10 @@ body.preloader-active {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #02060b;
+  background: #000;
   overflow: hidden;
   z-index: 4000;
   transition: opacity 0.8s ease, visibility 0.8s ease;
-}
-
-.preloader::before {
-  content: '';
-  position: absolute;
-  inset: -35%;
-  background:
-    radial-gradient(
-      circle at 20% 25%,
-      rgba(255, 255, 255, 0.1) 0%,
-      rgba(255, 255, 255, 0) 55%
-    ),
-    radial-gradient(
-      circle at 80% 30%,
-      rgba(24, 72, 114, 0.45) 0%,
-      rgba(2, 6, 11, 0) 58%
-    ),
-    radial-gradient(
-      circle at 65% 75%,
-      rgba(13, 46, 82, 0.5) 0%,
-      rgba(2, 6, 11, 0) 62%
-    );
-  opacity: 0.65;
-  filter: blur(12px);
-  animation: preloaderShimmer 14s ease-in-out infinite;
 }
 
 .preloader--closing {
@@ -62,127 +39,56 @@ body.preloader-active {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 1rem 2rem;
+  padding: 1.5rem;
 }
 
-.preloader__text {
-  font-family: 'Arial Black', Arial, sans-serif;
-  font-size: clamp(32px, 6vw, 120px);
-  letter-spacing: 0.5em;
-  text-transform: uppercase;
-  text-align: center;
+.preloader__svg {
+  width: min(72vw, 520px);
+  max-width: 520px;
   display: block;
 }
 
-.preloader__text--base {
-  color: transparent;
-  -webkit-text-stroke: 2px rgba(255, 255, 255, 0.35);
-  text-stroke: 2px rgba(255, 255, 255, 0.35);
-  opacity: 0.6;
+.preloader__svg-outline {
+  fill: transparent;
+  stroke: rgba(255, 255, 255, 0.75);
+  stroke-width: 4;
 }
 
-.preloader__text--fill {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  padding-bottom: 0.12em;
-  color: #d8f0ff;
-  overflow: hidden;
-  transform: translateY(110%);
-  animation: preloaderFill 2.8s ease-in-out forwards 0.6s;
-  text-shadow:
-    0 0 24px rgba(93, 175, 255, 0.45),
-    0 0 48px rgba(62, 115, 173, 0.35);
-  z-index: 1;
+.preloader__water-container {
+  transform-origin: center bottom;
+  transform: translateY(60%) scaleY(0);
+  animation: preloaderWaterRise 3.8s cubic-bezier(0.32, 0.02, 0.25, 1) forwards 0.3s;
 }
 
-.preloader__text--fill::before,
-.preloader__text--fill::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  bottom: -18%;
-  width: 160%;
-  height: 160%;
-  border-radius: 45%;
-  transform: translate(-50%, 0) rotate(0deg);
-  filter: blur(3px);
-  z-index: -1;
-  mix-blend-mode: screen;
+.preloader__water {
+  opacity: 0.95;
 }
 
-.preloader__text--fill::before {
-  background: rgba(64, 143, 219, 0.55);
-  animation: preloaderWave 6s linear infinite;
-}
-
-.preloader__text--fill::after {
-  background: rgba(150, 210, 255, 0.35);
-  animation: preloaderWave 8s linear infinite reverse;
-}
-
-@keyframes preloaderFill {
+@keyframes preloaderWaterRise {
   0% {
-    transform: translateY(110%);
+    transform: translateY(60%) scaleY(0);
   }
 
-  45% {
-    transform: translateY(25%);
-  }
-
-  70% {
-    transform: translateY(8%);
+  60% {
+    transform: translateY(6%) scaleY(0.92);
   }
 
   100% {
-    transform: translateY(0%);
-  }
-}
-
-@keyframes preloaderWave {
-  0% {
-    transform: translate(-50%, 0) rotate(0deg);
-  }
-
-  50% {
-    transform: translate(-50%, -6%) rotate(180deg);
-  }
-
-  100% {
-    transform: translate(-50%, 0) rotate(360deg);
-  }
-}
-
-@keyframes preloaderShimmer {
-  0% {
-    transform: scale(1) translate(0, 0);
-  }
-
-  50% {
-    transform: scale(1.05) translate(2%, -1%);
-  }
-
-  100% {
-    transform: scale(1) translate(0, 0);
+    transform: translateY(0) scaleY(1);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .preloader,
-  .preloader::before,
-  .preloader__text--fill,
-  .preloader__text--fill::before,
-  .preloader__text--fill::after,
-  .app-shell {
+  .app-shell,
+  .preloader__water-container {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
 
-  .preloader__text--fill {
-    transform: translateY(0);
+  .preloader__water-container {
+    transform: translateY(0) scaleY(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated preloader component with a water-fill logo animation
- delay rendering of the navigation and routes until loading completes with fade transitions
- style the preloader overlay, wave animation, and reduced-motion fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb2325dd08329b93205249103f9fe