### PR TITLE
Fix preloader mask coordinates

### DIFF
--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -42,8 +42,16 @@ const Preloader = ({ isClosing = false }) => {
             </text>
 
             {/* Маска: белое видно */}
-            <mask id={maskId}>
-              <rect width="100%" height="100%" fill="#000" />
+            <mask
+              id={maskId}
+              maskUnits="userSpaceOnUse"
+              maskContentUnits="userSpaceOnUse"
+              x="0"
+              y="0"
+              width={VB_WIDTH}
+              height={VB_HEIGHT}
+            >
+              <rect width={VB_WIDTH} height={VB_HEIGHT} fill="#000" />
               <use href={`#${textId}`} fill="#fff" />
             </mask>
 


### PR DESCRIPTION
## Summary
- ensure the SVG mask in the preloader uses the same coordinate system as the viewBox
- keep the wave pattern visible by explicitly sizing the mask rectangle to the viewBox dimensions

## Testing
- npm run build *(fails: missing @vitejs/plugin-react dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc3af313483298983cecbfe3927ac