### PR TITLE
Ensure preloader waves clip inside lettering

### DIFF
--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -7,6 +7,7 @@ const Preloader = ({ isClosing = false }) => {
 
   const textId = `${uid}-wordmark`
   const maskId = `${uid}-mask`
+  const clipId = `${uid}-clip`
   const waveTileId = `${uid}-wave-tile`
 
   // размеры в одном месте (чтобы не забыть поменять в нескольких тегах)
@@ -25,6 +26,7 @@ const Preloader = ({ isClosing = false }) => {
           className="preloader__svg"
           viewBox={`0 0 ${VB_WIDTH} ${VB_HEIGHT}`}
           xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
         >
           <defs>
             {/* Текст — только для маски */}
@@ -42,10 +44,23 @@ const Preloader = ({ isClosing = false }) => {
             </text>
 
             {/* Маска: белое видно */}
-            <mask id={maskId}>
-              <rect width="100%" height="100%" fill="#000" />
-              <use href={`#${textId}`} fill="#fff" />
+            <mask
+              id={maskId}
+              maskUnits="userSpaceOnUse"
+              maskContentUnits="userSpaceOnUse"
+              x="0"
+              y="0"
+              width={VB_WIDTH}
+              height={VB_HEIGHT}
+            >
+              <rect width={VB_WIDTH} height={VB_HEIGHT} fill="#000" />
+              <use href={`#${textId}`} xlinkHref={`#${textId}`} fill="#fff" />
             </mask>
+
+            {/* Дополнительный clipPath — надёжнее в некоторых браузерах */}
+            <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+              <use href={`#${textId}`} xlinkHref={`#${textId}`} />
+            </clipPath>
 
             {/* Тайловая волна (userSpaceOnUse!) */}
             <pattern id={waveTileId} width="160" height="60" patternUnits="userSpaceOnUse">
@@ -63,10 +78,18 @@ const Preloader = ({ isClosing = false }) => {
           </defs>
 
           {/* Контур текста для читабельности */}
-          <use className="preloader__svg-outline" href={`#${textId}`} />
+          <use
+            className="preloader__svg-outline"
+            href={`#${textId}`}
+            xlinkHref={`#${textId}`}
+          />
 
           {/* Вода видна только внутри текста */}
-          <g className="preloader__water-container" mask={`url(#${maskId})`}>
+          <g
+            className="preloader__water-container"
+            mask={`url(#${maskId})`}
+            clipPath={`url(#${clipId})`}
+          >
             <g className="preloader__wave preloader__wave--one">
               <rect
                 x={-VB_WIDTH}


### PR DESCRIPTION
## Summary
- ensure the SVG mask in the preloader uses the same coordinate system as the viewBox
- keep the wave pattern visible by explicitly sizing the mask rectangle to the viewBox dimensions
- add a clipPath fallback and xlinkHref references so the animated waves render inside the letters across browsers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc3af313483298983cecbfe3927ac