### PR TITLE
Restore animated text fill in preloader

### DIFF
--- a/src/components/Preloader.jsx
+++ b/src/components/Preloader.jsx
@@ -7,6 +7,14 @@ const Preloader = ({ isClosing = false }) => {
 
   const textId = `${uid}-wordmark`
   const maskId = `${uid}-mask`
+  const clipId = `${uid}-clip`
+
+  const RISE_DURATION = 5
+  const RISE_DELAY = 0.3
+  const WAVE_ONE_START_Y = VB_HEIGHT * 0.56
+  const WAVE_ONE_END_Y = VB_HEIGHT * 0.08
+  const WAVE_TWO_START_Y = VB_HEIGHT * 0.61
+  const WAVE_TWO_END_Y = VB_HEIGHT * 0.12
   const waveTileId = `${uid}-wave-tile`
 
   // размеры в одном месте (чтобы не забыть поменять в нескольких тегах)
@@ -42,10 +50,23 @@ const Preloader = ({ isClosing = false }) => {
             </text>
 
             {/* Маска: белое видно */}
-            <mask id={maskId}>
-              <rect width="100%" height="100%" fill="#000" />
+            <mask
+              id={maskId}
+              maskUnits="userSpaceOnUse"
+              maskContentUnits="userSpaceOnUse"
+              x="0"
+              y="0"
+              width={VB_WIDTH}
+              height={VB_HEIGHT}
+            >
+              <rect width={VB_WIDTH} height={VB_HEIGHT} fill="#000" />
               <use href={`#${textId}`} fill="#fff" />
             </mask>
+
+            {/* Альтернативный clipPath — так анимации работают в Safari/Firefox */}
+            <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+              <use href={`#${textId}`} />
+            </clipPath>
 
             {/* Тайловая волна (userSpaceOnUse!) */}
             <pattern id={waveTileId} width="160" height="60" patternUnits="userSpaceOnUse">
@@ -66,24 +87,69 @@ const Preloader = ({ isClosing = false }) => {
           <use className="preloader__svg-outline" href={`#${textId}`} />
 
           {/* Вода видна только внутри текста */}
-          <g className="preloader__water-container" mask={`url(#${maskId})`}>
+          <g
+            className="preloader__water-container"
+            mask={`url(#${maskId})`}
+            clipPath={`url(#${clipId})`}
+          >
+            <rect
+              className="preloader__water-level"
+              x="0"
+              y={VB_HEIGHT}
+              width={VB_WIDTH}
+              height={VB_HEIGHT}
+            >
+              <animate
+                attributeName="y"
+                values={`${VB_HEIGHT};${VB_HEIGHT * 0.12};0`}
+                keyTimes="0;0.6;1"
+                dur={`${RISE_DURATION}s`}
+                begin={`${RISE_DELAY}s`}
+                fill="freeze"
+              />
+              <animate
+                attributeName="height"
+                values={`0;${VB_HEIGHT * 0.88};${VB_HEIGHT}`}
+                keyTimes="0;0.6;1"
+                dur={`${RISE_DURATION}s`}
+                begin={`${RISE_DELAY}s`}
+                fill="freeze"
+              />
+            </rect>
+
             <g className="preloader__wave preloader__wave--one">
               <rect
                 x={-VB_WIDTH}
-                y={VB_HEIGHT * 0.56}        // позиция уровня
+                y={WAVE_ONE_START_Y}        // позиция уровня
                 width={VB_WIDTH * 2.2}
                 height="80"
                 fill={`url(#${waveTileId})`}
+              />
+              <animate
+                attributeName="y"
+                values={`${WAVE_ONE_START_Y};${WAVE_ONE_END_Y};${WAVE_ONE_END_Y}`}
+                keyTimes="0;0.6;1"
+                dur={`${RISE_DURATION}s`}
+                begin={`${RISE_DELAY}s`}
+                fill="freeze"
               />
             </g>
 
             <g className="preloader__wave preloader__wave--two">
               <rect
                 x={-VB_WIDTH}
-                y={VB_HEIGHT * 0.61}
+                y={WAVE_TWO_START_Y}
                 width={VB_WIDTH * 2.2}
                 height="80"
                 fill={`url(#${waveTileId})`}
+              />
+              <animate
+                attributeName="y"
+                values={`${WAVE_TWO_START_Y};${WAVE_TWO_END_Y};${WAVE_TWO_END_Y}`}
+                keyTimes="0;0.6;1"
+                dur={`${RISE_DURATION}s`}
+                begin={`${RISE_DELAY}s`}
+                fill="freeze"
               />
             </g>
           </g>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,6 @@
 
 /* === Настраиваемые длительности/скорости === */
 :root{
-  --preloader-rise: 5s;
   --preloader-fade: 0.8s;
   --wave-speed-1: 6s;
   --wave-speed-2: 9s;
@@ -63,24 +62,15 @@ body.preloader-active {
 }
 
 
-.preloader__water-container,
-.preloader__wave {
-  transform-box: fill-box;     /* ключевая строка */
-}
-
 
 /* ====== ВОДА ВНУТРИ ТЕКСТА ====== */
-/* Подъём уровня */
-.preloader__water-container{
-  transform-origin: center bottom;
-  transform: translateY(60%) scaleY(0);
-  animation: preloaderWaterRise var(--preloader-rise) cubic-bezier(.32,.02,.25,1) forwards .3s;
+.preloader__water-level {
+  fill: #3d9ff5;
+  opacity: 0.85;
 }
 
 /* Бегущие волны — видны только внутри маски текста (см. JSX) */
-.preloader__wave { will-change: transform; }
-
-.preloader__wave{ will-change: transform; }
+.preloader__wave { will-change: transform; transform-box: fill-box; }
 @keyframes waveX {
   from { transform: translateX(0); }
   to   { transform: translateX(-160px); } /* ширина тайла */
@@ -91,12 +81,6 @@ body.preloader-active {
 
 .preloader__water {
   opacity: 0.95; /* если нужен дополнительный белый слой */
-}
-
-@keyframes preloaderWaterRise{
-  0%{ transform: translateY(60%) scaleY(0); }
-  60%{ transform: translateY(6%)  scaleY(.92); }
-  100%{ transform: translateY(0)   scaleY(1); }
 }
 
 /* @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- add a clipPath fallback so masked text is revealed consistently across browsers
- animate the water level directly in SVG to restore the rising fill effect inside the letters
- adjust styles for the base fill and keep the horizontal wave motion using CSS

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc3af313483298983cecbfe3927ac